### PR TITLE
Set max version of Bokeh

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import setup, find_packages
 
 setup(
     name="bulk",
-    version="0.1.1",
+    version="0.1.2",
     packages=find_packages(),
-    install_requires=["typer>=0.4.1", "bokeh>=2.4.3", "pandas>=1.0.0"],
+    install_requires=["typer>=0.4.1,<1.0.0", "bokeh>=2.4.3,<3.0.0", "pandas>=1.0.0,<2.0.0"],
     extras_require={
         "dev": ["pytest-playwright==0.3.0"],
     },


### PR DESCRIPTION
This PR should fix https://github.com/koaning/bulk/issues/34. Setting a max version on all dependencies should prevent issues, mainly with Bokeh for now. 