### PR TITLE
Preserve all columns when saving csvs.

### DIFF
--- a/bulk/__main__.py
+++ b/bulk/__main__.py
@@ -32,18 +32,13 @@ app.add_typer(util_app, name="util")
 def text(
     path: pathlib.Path = typer.Argument(..., help="Path to .csv file", exists=True),
     keywords: str = typer.Option(None, help="Keywords to highlight"),
-    save_all_columns: bool = typer.Option(
-        False, is_flag=True, help="Save all associated column data"
-    ),
     port: int = typer.Option(5006, help="Port number"),
 ):
     """Bulk Labelling for Text"""
     if keywords:
         keywords = keywords.split(",")
     server = Server(
-        {"/": bulk_text(path, keywords=keywords, save_all_columns=save_all_columns)},
-        io_loop=IOLoop(),
-        port=port,
+        {"/": bulk_text(path, keywords=keywords)}, io_loop=IOLoop(), port=port
     )
     server.start()
     host = f"http://localhost:{port}/"
@@ -55,17 +50,10 @@ def text(
 @app.command("image")
 def image(
     path: pathlib.Path = typer.Argument(..., help="Path to .csv file", exists=True),
-    save_all_columns: bool = typer.Option(
-        False, is_flag=True, help="Save all associated column data"
-    ),
     port: int = typer.Option(5006, help="Port number"),
 ):
     """Bulk Labelling for Images"""
-    server = Server(
-        {"/": bulk_images(path, save_all_columns=save_all_columns)},
-        io_loop=IOLoop(),
-        port=port,
-    )
+    server = Server({"/": bulk_images(path)}, io_loop=IOLoop(), port=port)
     server.start()
     host = f"http://localhost:{port}/"
     print(f"About to serve `bulk` over at {host}.")

--- a/bulk/__main__.py
+++ b/bulk/__main__.py
@@ -32,13 +32,18 @@ app.add_typer(util_app, name="util")
 def text(
     path: pathlib.Path = typer.Argument(..., help="Path to .csv file", exists=True),
     keywords: str = typer.Option(None, help="Keywords to highlight"),
+    save_all_columns: bool = typer.Option(
+        False, is_flag=True, help="Save all associated column data"
+    ),
     port: int = typer.Option(5006, help="Port number"),
 ):
     """Bulk Labelling for Text"""
     if keywords:
         keywords = keywords.split(",")
     server = Server(
-        {"/": bulk_text(path, keywords=keywords)}, io_loop=IOLoop(), port=port
+        {"/": bulk_text(path, keywords=keywords, save_all_columns=save_all_columns)},
+        io_loop=IOLoop(),
+        port=port,
     )
     server.start()
     host = f"http://localhost:{port}/"
@@ -50,10 +55,17 @@ def text(
 @app.command("image")
 def image(
     path: pathlib.Path = typer.Argument(..., help="Path to .csv file", exists=True),
+    save_all_columns: bool = typer.Option(
+        False, is_flag=True, help="Save all associated column data"
+    ),
     port: int = typer.Option(5006, help="Port number"),
 ):
     """Bulk Labelling for Images"""
-    server = Server({"/": bulk_images(path)}, io_loop=IOLoop(), port=port)
+    server = Server(
+        {"/": bulk_images(path, save_all_columns=save_all_columns)},
+        io_loop=IOLoop(),
+        port=port,
+    )
     server.start()
     host = f"http://localhost:{port}/"
     print(f"About to serve `bulk` over at {host}.")

--- a/bulk/cli/image.py
+++ b/bulk/cli/image.py
@@ -37,7 +37,7 @@ def grouper(iterable, n, *, incomplete="fill", fillvalue=None):
         raise ValueError("Expected fill, strict, or ignore")
 
 
-def bulk_images(path, save_all_columns=False):
+def bulk_images(path):
     def bkapp(doc):
         df = pd.read_csv(path).assign(
             image=lambda d: [encode_image(p) for p in d["path"]]
@@ -88,12 +88,7 @@ def bulk_images(path, save_all_columns=False):
         def save():
             """Callback used to save highlighted data points"""
             global highlighted_idx
-            if save_all_columns:
-                df.iloc[highlighted_idx].to_csv(text_filename.value, index=False)
-            else:
-                df.iloc[highlighted_idx][["path"]].to_csv(
-                    text_filename.value, index=False
-                )
+            df.iloc[highlighted_idx].to_csv(text_filename.value, index=False)
 
         source = ColumnDataSource(data=dict())
         source_orig = ColumnDataSource(data=df)

--- a/bulk/cli/image.py
+++ b/bulk/cli/image.py
@@ -37,7 +37,7 @@ def grouper(iterable, n, *, incomplete="fill", fillvalue=None):
         raise ValueError("Expected fill, strict, or ignore")
 
 
-def bulk_images(path):
+def bulk_images(path, save_all_columns=False):
     def bkapp(doc):
         df = pd.read_csv(path).assign(
             image=lambda d: [encode_image(p) for p in d["path"]]
@@ -88,7 +88,12 @@ def bulk_images(path):
         def save():
             """Callback used to save highlighted data points"""
             global highlighted_idx
-            df.iloc[highlighted_idx][["path"]].to_csv(text_filename.value, index=False)
+            if save_all_columns:
+                df.iloc[highlighted_idx].to_csv(text_filename.value, index=False)
+            else:
+                df.iloc[highlighted_idx][["path"]].to_csv(
+                    text_filename.value, index=False
+                )
 
         source = ColumnDataSource(data=dict())
         source_orig = ColumnDataSource(data=df)

--- a/bulk/cli/text.py
+++ b/bulk/cli/text.py
@@ -21,7 +21,7 @@ def determine_keyword(text, keywords):
     return "none"
 
 
-def bulk_text(path, keywords=None):
+def bulk_text(path, keywords=None, save_all_columns=False):
     def bkapp(doc):
         df = pd.read_csv(path)
         df["alpha"] = 0.5
@@ -45,7 +45,12 @@ def bulk_text(path, keywords=None):
         def save():
             """Callback used to save highlighted data points"""
             global highlighted_idx
-            df.iloc[highlighted_idx][["text"]].to_csv(text_filename.value, index=False)
+            if save_all_columns:
+                df.iloc[highlighted_idx].to_csv(text_filename.value, index=False)
+            else:
+                df.iloc[highlighted_idx][["text"]].to_csv(
+                    text_filename.value, index=False
+                )
 
         source = ColumnDataSource(data=dict())
         source_orig = ColumnDataSource(data=df)

--- a/bulk/cli/text.py
+++ b/bulk/cli/text.py
@@ -21,7 +21,7 @@ def determine_keyword(text, keywords):
     return "none"
 
 
-def bulk_text(path, keywords=None, save_all_columns=False):
+def bulk_text(path, keywords=None):
     def bkapp(doc):
         df = pd.read_csv(path)
         df["alpha"] = 0.5
@@ -45,12 +45,7 @@ def bulk_text(path, keywords=None, save_all_columns=False):
         def save():
             """Callback used to save highlighted data points"""
             global highlighted_idx
-            if save_all_columns:
-                df.iloc[highlighted_idx].to_csv(text_filename.value, index=False)
-            else:
-                df.iloc[highlighted_idx][["text"]].to_csv(
-                    text_filename.value, index=False
-                )
+            df.iloc[highlighted_idx].to_csv(text_filename.value, index=False)
 
         source = ColumnDataSource(data=dict())
         source_orig = ColumnDataSource(data=df)


### PR DESCRIPTION
I added a command line flag `save-all-columns` to override the default behavior of saving just the `text` column or `path` column. This enables the the ability to save all the column data. I personally like the default, but once I establish clusters of interest I often want all the data. 

I just needed something quickly but considering it a little further there was discussion in issue #19 of moving towards a config. I wasn't sure if maybe this option would be better added to the UI? @koaning mentioned that he is interested in refactoring some of the code to be more modular and if we pull it to the UI might at least make refactoring simpler?

I wasn't exactly sure sure of the PR process. Looks like you use Black, so I did, and all tests pass.