### PR TITLE
Update csv filename in Bulk Image example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ dataf = pd.DataFrame({
 X = image_emb_pipeline.fit_transform(dataf)
 dataf['x'] = X[:, 0]
 dataf['y'] = X[:, 1]
-dataf.to_csv(f"pets-xception.csv", index=False)
+dataf.to_csv("ready.csv", index=False)
 ```
 
 This generates a csv file that can be loaded in bulk via; 


### PR DESCRIPTION
Thanks for all your work on bulk! 

I noticed the other examples and references all use ready.csv as the output file (including the example for actually making the `python -m bulk image ready.csv` call), so I thought it might be worthwhile to update the example. 