### PR TITLE
Allowing pandas in version >=2.0.0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,7 +29,7 @@ jobs:
         python -m bulk text tests/data/text.csv --port 5006 & sleep 1
     - name: Start vision server in background
       run: |
-        python -m bulk text tests/data/vision.csv --port 7007 & sleep 1
+        python -m bulk image tests/data/vision.csv --port 7007 & sleep 1
     - name: Curl the text server
       run: |
         curl http://localhost:5006

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="bulk",
     version="0.3.0",
     packages=find_packages(),
-    install_requires=["radicli>=0.0.8,<0.1.0", "bokeh>=2.4.3,<3.0.0", "pandas>=1.0.0,<2.0.0", "wasabi>=0.9.1"],
+    install_requires=["radicli>=0.0.8,<0.1.0", "bokeh>=2.4.3,<3.0.0", "pandas>=1.0.0", "wasabi>=0.9.1"],
     extras_require={
         "dev": ["pytest-playwright==0.3.0"],
     },


### PR DESCRIPTION
pandas >=2.0.0 has been out for a while, we can allow it here to help with some dependency conflicts with other newer packages bulk gets installed along.