### PR TITLE
Addion of some environment variables related to the plot and display

### DIFF
--- a/bulk/cli/text.py
+++ b/bulk/cli/text.py
@@ -18,7 +18,7 @@ from bulk._bokeh_utils import download_js_code, read_file, save_file
 
 
 def _env_to_bool(value: str):
-    value = value.lower().strip()
+    value = str(value).lower().strip()
     return value in ["1", "t", "true"]
 
 

--- a/bulk/cli/text.py
+++ b/bulk/cli/text.py
@@ -17,6 +17,11 @@ from wasabi import msg
 from bulk._bokeh_utils import download_js_code, read_file, save_file
 
 
+def _env_to_bool(value: str):
+    value = value.lower().strip()
+    return value in ["1", "t", "true"]
+
+
 def bulk_text(path, keywords=None, download=True):
     def bkapp(doc):
         df, colormap, orig_cols = read_file(path, keywords=keywords)
@@ -29,6 +34,10 @@ def bulk_text(path, keywords=None, download=True):
         highlighted_idx = []
 
         columns = [TableColumn(field="text", title="text")]
+
+        # If need to display the `label` column
+        if _env_to_bool(os.environ.get("BULK_DISPLAY_LABEL", False)):
+            columns.append(TableColumn(field="label", title="label"))
 
         def update(attr, old, new):
             """Callback used for plot update when lasso selecting"""

--- a/bulk/cli/text.py
+++ b/bulk/cli/text.py
@@ -1,8 +1,16 @@
+import os
 import numpy as np
 import pandas as pd
 from bokeh.layouts import column, row
-from bokeh.models import (Button, ColorBar, ColumnDataSource, CustomJS,
-                          DataTable, TableColumn, TextInput)
+from bokeh.models import (
+    Button,
+    ColorBar,
+    ColumnDataSource,
+    CustomJS,
+    DataTable,
+    TableColumn,
+    TextInput,
+)
 from bokeh.plotting import figure
 from wasabi import msg
 
@@ -65,7 +73,7 @@ def bulk_text(path, keywords=None, download=True):
         circle_kwargs = {
             "x": "x",
             "y": "y",
-            "size": 1,
+            "size": int(os.environ.get("BULK_CIRCLE_SIZE", 1)),
             "source": source_orig,
             "alpha": "alpha",
         }
@@ -75,10 +83,10 @@ def bulk_text(path, keywords=None, download=True):
             p.add_layout(color_bar, "right")
 
         scatter = p.circle(**circle_kwargs)
-        p.plot_width = 300
+        p.plot_width = int(os.environ.get("BULK_PLOT_WIDTH", 300))
         if "color" in df.columns:
-            p.plot_width = 350
-        p.plot_height = 300
+            p.plot_width = p.plot_width + 50
+        p.plot_height = int(os.environ.get("BULK_PLOT_HEIGHT", 300))
 
         scatter.data_source.selected.on_change("indices", update)
 


### PR DESCRIPTION
The only changes are the introduction of the following environment variables that help in displaying the plot and tables. This could be useful if we want to have more flexibility in resizing the plot area and other display params.

## Related to Plot

- `BULK_CIRCLE_SIZE`: Controls the size of the circle markers (existing default of`1`)
- `BULK_PLOT_WIDTH`: Controls the width of the plot region (existing default of `300`)
- `BULK_PLOT_HEIGHT`: Controls the height of the plot region (existing default of `300)`)

## Related to table

- `BULK_DISPLAY_LABEL`: If there's an existing column called `label`, it will display alongside the `text` in the table region

---

Related: https://github.com/koaning/bulk/issues/21#issuecomment-1408985101

Other alternative could be some sort of config management. And probably there are more things to configure here.