### PR TITLE
Fix console entry point to allow direct execution with uvx

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ python -m bulk text ready.csv
 ```
 
 If you're looking for an example file to play around with you can download
-[the demo .csv file](https://github.com/koaning/bulk/blob/main/cluestarred.csv) in this repository. This dataset 
+[the demo .csv file](https://github.com/koaning/bulk/blob/main/utils/df.csv) in this repository. This dataset 
 contains a subset of a dataset found on Kaggle. You can find the original [here](https://www.kaggle.com/datasets/thoughtvector/customer-support-on-twitter).
 
 ### Extra Settings

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'bulk = bulk.__main__:app',
+            'bulk = bulk.__main__:cli.run',
         ],
     },
 )


### PR DESCRIPTION
Hi @koaning,

Currently, when trying to use bulk with `uvx` directly:

```python
uvx bulk text df.csv
```

It raises this **error**:

```bash
Traceback (most recent call last):
  File "/Users/amitness/Library/Caches/uv/archive-v0/Ai18k3ieJ7bpU38lhPOKc/bin/bulk", line 7, in <module>
    from bulk.__main__ import app
ImportError: cannot import name 'app' from 'bulk.__main__' (/Users/amitness/Library/Caches/uv/archive-v0/Ai18k3ieJ7bpU38lhPOKc/lib/python3.8/site-packages/bulk/__main__.py)
```

But, if you run it as a module, it works as usual because that doesn't invoke the console script.
```
python -m bulk text df.csv
```

I found that the reason is because the entrypoint defined in `console_scripts` is wrong and still set to the typer app. While the code has switched to click for the command line parsing. 

I have pushed a fix for this. As such, both the scripts below will work now.

```
bulk text df.csv
uvx bulk text df.csv
```

You can also test my changes via this command using `df.csv` from [here](https://github.com/koaning/bulk/blob/main/utils/df.csv)
```
uvx --from=git+https://github.com/amitness/bulk@fix-uvx bulk text df.csv
```